### PR TITLE
Remove random numbers from names (fix recent issues)

### DIFF
--- a/Image_processing.lua
+++ b/Image_processing.lua
@@ -70,7 +70,7 @@ ImageBlock = {
 			o.blue = 0
 			o.type = image_type
 			o.color = image_color
-			o.name = (_addon and _addon.name or 'image') .. '_gensym_' .. tostring(t):sub(8) .. '_%.8x':format(16^8 * math.random()):sub(3)
+			o.name = 'block_' .. order
 			o.x = settings.display.pos.x
 			o.y = settings.display.pos.y
 		elseif image_type == 'logo' then
@@ -79,7 +79,7 @@ ImageBlock = {
 			o.type = image_type
 			o.color = image_color
 			o.image_path = windower.addon_path..'textures/'..settings.image_folder_name..'/'.. image_type ..'.png'
-			o.name = (_addon and _addon.name or 'image') .. '_gensym_' .. tostring(t):sub(8) .. '_%.8x':format(16^8 * math.random()):sub(3)
+			o.name = 'block_' .. order
 			o.x = sections.background:position_x()
 			o.y = sections.background:position_y()
 			check_positions()
@@ -91,7 +91,7 @@ ImageBlock = {
 				o.type = image_type
 				o.color = image_color
 				o.image_path = windower.addon_path..'textures/'..settings.image_folder_name..'/'..image_color ..'.png'
-				o.name = (_addon and _addon.name or 'image') .. '_gensym_' .. tostring(t):sub(8) .. '_%.8x':format(16^8 * math.random()):sub(3)
+				o.name = 'block_' .. order
 				o.x, o.y = get_position(o)
 				o.text = {}
 				


### PR DESCRIPTION
Starting last month, people started to experience issues such as flickering and missing information:

https://www.ffxiah.com/forum/topic/52145/finally-releasing-this-addon-gearinfo/12/#3542688

https://thumbs.gfycat.com/SentimentalPowerfulHedgehog-mobile.mp4

I tracked it down to the random number generator being used for ImageBlock names very often returned "0000000" (or rather, it's the conversion from decimal to hex that ended up doing it). This meant many of the texts and images could have the same name, as they were sharing the 0000000 suffix.

After checking how these ImageBlocks are created, I saw that each has a unique "order" passed in. Using this value for the naming instead of something random means that the blocks are still uniquely named, but there are no errors related to the random number.

I did ask in Windower discord if they could think of a reason it may "suddenly" stop working properly but there was no definitive answer.

A couple of users have tested my fix and report that it's working fine.